### PR TITLE
Support private repositories and cleanup

### DIFF
--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -4,11 +4,15 @@ import logging
 import json
 import re
 
+try:
+    from urlparse import urljoin, urlparse
+except ImportError:
+    from urllib.parse import urljoin, urlparse
+
 from django.conf import settings
 from requests.exceptions import RequestException
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.gitlab.views import GitLabOAuth2Adapter
-from urlparse import urljoin
 
 from readthedocs.restapi.client import api
 
@@ -23,7 +27,9 @@ class GitLabService(Service):
     """Provider service for GitLab"""
 
     adapter = GitLabOAuth2Adapter
-    url_pattern = re.compile(re.escape(adapter.provider_base_url))
+    # Just use the network location to determine if it's a GitLab project
+    # because private repos have another base url, eg. git@gitlab.example.com
+    url_pattern = re.compile(re.escape(urlparse(adapter.provider_base_url).netloc))
     default_avatar = {
         'repo': urljoin(settings.MEDIA_URL, 'images/fa-bookmark.svg'),
         'org':  urljoin(settings.MEDIA_URL, 'images/fa-users.svg'),

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -178,17 +178,6 @@ class GitLabService(Service):
         :rtype: bool
         """
         session = self.get_session()
-
-        # See: http://doc.gitlab.com/ce/api/projects.html#add-project-hook
-        data = json.dumps({
-            'id': settings.PRODUCTION_DOMAIN,
-            'push_events': True,
-            'issues_events': False,
-            'merge_requests_events': False,
-            'note_events': False,
-            'tag_push_events': True,
-            'url': u'https://{0}/gitlab'.format(settings.PRODUCTION_DOMAIN),
-        })
         resp = None
         repositories = RemoteRepository.objects.filter(clone_url=project.vcs_repo().repo_url)
 
@@ -197,6 +186,17 @@ class GitLabService(Service):
             return False, resp
 
         repo_id = repositories[0].get_serialized()['id']
+        # See: http://doc.gitlab.com/ce/api/projects.html#add-project-hook
+        data = json.dumps({
+            'id': repo_id,
+            'push_events': True,
+            'issues_events': False,
+            'merge_requests_events': False,
+            'note_events': False,
+            'tag_push_events': True,
+            'url': u'https://{0}/gitlab'.format(settings.PRODUCTION_DOMAIN),
+        })
+
         try:
             resp = session.post(
                 u'{url}/api/v3/projects/{repo_id}/hooks'.format(

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -4,7 +4,10 @@ import logging
 import json
 import re
 
-from urlparse import urljoin, urlparse
+try:
+    from urlparse import urljoin, urlparse
+except ImportError:
+    from urllib.parse import urljoin, urlparse  # noqa
 
 from django.conf import settings
 from requests.exceptions import RequestException

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -178,7 +178,7 @@ class GitLabService(Service):
 
         # See: http://doc.gitlab.com/ce/api/projects.html#add-project-hook
         data = json.dumps({
-            'id': 'readthedocs',
+            'id': settings.PRODUCTION_DOMAIN,
             'push_events': True,
             'issues_events': False,
             'merge_requests_events': False,

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -4,10 +4,7 @@ import logging
 import json
 import re
 
-try:
-    from urlparse import urljoin, urlparse
-except ImportError:
-    from urllib.parse import urljoin, urlparse
+from urlparse import urljoin, urlparse
 
 from django.conf import settings
 from requests.exceptions import RequestException


### PR DESCRIPTION
The url_pattern of the GitLabService excluded private repositories. Therefore creating a Webhook didn't work as expected.

Now the url_pattern is just the network location of the provider_base_url.
